### PR TITLE
Remediate MetalLB Operator failure with RBAC config

### DIFF
--- a/clusters/moo-cluster/metallb/infrastructure.yaml
+++ b/clusters/moo-cluster/metallb/infrastructure.yaml
@@ -28,6 +28,14 @@ spec:
   prune: true
   validation: client
   healthChecks:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: speaker
+      namespace: metallb-system
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: controller
+      namespace: metallb-system
     - apiVersion: metallb.io/v1beta1
       kind: MetalLB
       name: metallb

--- a/infrastructure/metallb/kustomization.yaml
+++ b/infrastructure/metallb/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - github.com/metallb/metallb-operator//config/default?ref=v0.10.2
+  - github.com/metallb/metallb-operator//config/metallb_rbac?ref=v0.10.2
 namespace: metallb-system


### PR DESCRIPTION
`config/metallb_rbac` contains additional necessary roles and service accounts for the MetalLB operator to function.

It does not seem to have a reliable Ready condition/status of its own. The Kustomization was proceeding as if it was ready, but the `controller` Deployment and `speaker` DaemonSet did not come alive without their ServiceAccounts.

This should remediate both issues, the missing RBAC roles and the failure to provide health status at the Custom Resource level.