### PR TITLE
Internal ingress lb

### DIFF
--- a/apps/gitea/helmrelease.yaml
+++ b/apps/gitea/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
       enabled: true
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-production
-        kubernetes.io/ingress.class: nginx
+        kubernetes.io/ingress.class: internal
       hosts:
         - host: gitea.hephy.pro
           paths:

--- a/apps/jenkins/helmrelease.yaml
+++ b/apps/jenkins/helmrelease.yaml
@@ -43,23 +43,23 @@ spec:
         apiVersion: networking.k8s.io/v1
         hostName: jenkins.hephy.pro
         annotations:
-          cert-manager.io/cluster-issuer: letsencrypt-production
-          # cert-manager.io/cluster-issuer: letsencrypt-internal
+          #cert-manager.io/cluster-issuer: letsencrypt-production
           kubernetes.io/ingress.class: internal
         tls:
           - secretName: jenkins.hephy.pro
             hosts:
               - jenkins.hephy.pro
-      # secondaryIngress:
-      #   enabled: true
-      #   apiVersion: networking.k8s.io/v1
-      #   hostName: jenkins.hephy.pro
-      #   annotations:
-      #     cert-manager.io/cluster-issuer: letsencrypt-public
-      #   tls:
-      #     - secretName: jenkins.hephy.pro
-      #       hosts:
-      #         - jenkins.hephy.pro
+      secondaryIngress:
+        enabled: true
+        apiVersion: networking.k8s.io/v1
+        hostName: jenkins.hephy.pro
+        annotations:
+          #cert-manager.io/cluster-issuer: letsencrypt-production
+          kubernetes.io/ingress.class: public
+        tls:
+          - secretName: jenkins.hephy.pro
+            hosts:
+              - jenkins.hephy.pro
 
       JCasC:
         defaultConfig: false

--- a/apps/jenkins/helmrelease.yaml
+++ b/apps/jenkins/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-production
           # cert-manager.io/cluster-issuer: letsencrypt-internal
-          kubernetes.io/ingress.class: nginx
+          kubernetes.io/ingress.class: internal
         tls:
           - secretName: jenkins.hephy.pro
             hosts:

--- a/clusters/moo-cluster/flux-system/gitno-hephy-pro-ingress.yaml
+++ b/clusters/moo-cluster/flux-system/gitno-hephy-pro-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: webhook-receiver
   namespace: flux-system
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: "public"
     cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"

--- a/infrastructure/cert-manager-issuers/example-clusterissuer.yaml
+++ b/infrastructure/cert-manager-issuers/example-clusterissuer.yaml
@@ -11,4 +11,4 @@ spec:
     solvers:
     - http01:
        ingress:
-         class: nginx
+         class: public

--- a/infrastructure/cert-manager-issuers/letsencrypt-production-clusterissuer.yaml
+++ b/infrastructure/cert-manager-issuers/letsencrypt-production-clusterissuer.yaml
@@ -11,4 +11,4 @@ spec:
     solvers:
     - http01:
        ingress:
-         class: nginx
+         class: public

--- a/infrastructure/ingress-nginx/internal-helmrelease.yaml
+++ b/infrastructure/ingress-nginx/internal-helmrelease.yaml
@@ -1,10 +1,11 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
-  name: ingress-nginx
+  name: internal-ingress
   namespace: ingress-nginx
 spec:
   interval: 45m
+  releaseName: ingress-internal
   chart:
     spec:
       chart: ingress-nginx
@@ -18,3 +19,6 @@ spec:
     controller:
       extraArgs:
         enable-ssl-passthrough: ""
+      ingressClassResource:
+        name: internal
+        default: true

--- a/infrastructure/ingress-nginx/public-helmrelease.yaml
+++ b/infrastructure/ingress-nginx/public-helmrelease.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: public-ingress
+  namespace: ingress-nginx
+spec:
+  interval: 45m
+  releaseName: ingress-public
+  dependsOn:
+    - name: internal-ingress
+  chart:
+    spec:
+      chart: ingress-nginx
+      version: '^4.0.1'
+      sourceRef:
+        kind: HelmRepository
+        name: ingress-nginx
+        namespace: flux-system
+      interval: 15m
+  values:
+    controller:
+      extraArgs:
+        enable-ssl-passthrough: ""
+      ingressClassResource:
+        name: public
+        default: false

--- a/infrastructure/keycloak/keycloak-ingress.yaml
+++ b/infrastructure/keycloak/keycloak-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: keycloak
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: internal
 spec:
   tls:
     - hosts:

--- a/infrastructure/kube-oidc-proxy/helmrelease.yaml
+++ b/infrastructure/kube-oidc-proxy/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-production
         nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-        kubernetes.io/ingress.class: nginx
+        kubernetes.io/ingress.class: internal
       hosts:
         - host: kube.sso.moo.hephy.pro
           paths:


### PR DESCRIPTION
Make up a new internal ingress / public ingress schema, and convert all existing ingress entries to the internal-only kind, unless they are webhooks that must necessarily be public.

(This includes cert-manager, and there is an interesting loophole here in that internal services can use the production `ClusterIssuer`, so they can be public only for the purposes of getting an TLS certificate from LetsEncrypt, but always private otherwise, and clients utilizing the ingresses need not know about or do special configuration for this scheme to succeed.)

The internal ingress is the private one, so internal services can omit the `IngressClass` and they will be safely exposed on the internal network only, via the domain name pointer `nginx-internal.nerdland.local` (which can even be used in a CNAME!)

(The DNS entry is handled manually via dd-wrt)