### PR TITLE
Lockdown ingress

### DIFF
--- a/apps/gitea/helmrelease.yaml
+++ b/apps/gitea/helmrelease.yaml
@@ -34,9 +34,10 @@ spec:
         existingClaim: data-gitea-postgresql-0
     ingress:
       enabled: true
+      ingressClassName: internal
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-production
-        kubernetes.io/ingress.class: internal
+        #kubernetes.io/ingress.class: internal
       hosts:
         - host: gitea.hephy.pro
           paths:

--- a/apps/jenkins/helmrelease.yaml
+++ b/apps/jenkins/helmrelease.yaml
@@ -42,9 +42,10 @@ spec:
         enabled: true
         apiVersion: networking.k8s.io/v1
         hostName: jenkins.hephy.pro
+        ingressClassName: internal
         annotations:
           #cert-manager.io/cluster-issuer: letsencrypt-production
-          kubernetes.io/ingress.class: internal
+          #kubernetes.io/ingress.class: internal
         tls:
           - secretName: jenkins.hephy.pro
             hosts:
@@ -53,9 +54,10 @@ spec:
         enabled: true
         apiVersion: networking.k8s.io/v1
         hostName: jenkins.hephy.pro
+        ingressClassName: public
         annotations:
           #cert-manager.io/cluster-issuer: letsencrypt-production
-          kubernetes.io/ingress.class: public
+          #kubernetes.io/ingress.class: public
         tls:
           - secretName: jenkins.hephy.pro
             hosts:

--- a/clusters/moo-cluster/flux-system/gitno-hephy-pro-ingress.yaml
+++ b/clusters/moo-cluster/flux-system/gitno-hephy-pro-ingress.yaml
@@ -4,11 +4,12 @@ metadata:
   name: webhook-receiver
   namespace: flux-system
   annotations:
-    kubernetes.io/ingress.class: "public"
+    #kubernetes.io/ingress.class: "public"
     cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
+  ingressClassName: public
   rules:
   - host: gitno.hephy.pro
     http:

--- a/clusters/moo-cluster/ingress-nginx/infrastructure.yaml
+++ b/clusters/moo-cluster/ingress-nginx/infrastructure.yaml
@@ -14,6 +14,10 @@ spec:
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment
-      name: ingress-nginx-controller
+      name: ingress-internal-ingress-nginx-controller
       namespace: ingress-nginx
-  timeout: 5m0s
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: ingress-public-ingress-nginx-controller
+      namespace: ingress-nginx
+  timeout: 8m0s

--- a/infrastructure/ingress-nginx/internal-helmrelease.yaml
+++ b/infrastructure/ingress-nginx/internal-helmrelease.yaml
@@ -22,3 +22,5 @@ spec:
       ingressClassResource:
         name: internal
         default: true
+        parameters:
+          ingress-class: internal

--- a/infrastructure/ingress-nginx/public-helmrelease.yaml
+++ b/infrastructure/ingress-nginx/public-helmrelease.yaml
@@ -24,3 +24,5 @@ spec:
       ingressClassResource:
         name: public
         default: false
+        parameters:
+          ingress-class: public

--- a/infrastructure/keycloak/keycloak-ingress.yaml
+++ b/infrastructure/keycloak/keycloak-ingress.yaml
@@ -6,6 +6,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-production
     kubernetes.io/ingress.class: internal
 spec:
+  ingressClassName: internal
   tls:
     - hosts:
       - keycloak.hephy.pro

--- a/infrastructure/kube-oidc-proxy/helmrelease.yaml
+++ b/infrastructure/kube-oidc-proxy/helmrelease.yaml
@@ -28,10 +28,11 @@ spec:
     
     ingress:
       enabled: true
+      ingressClassName: internal
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-production
         nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-        kubernetes.io/ingress.class: internal
+        #kubernetes.io/ingress.class: internal
       hosts:
         - host: kube.sso.moo.hephy.pro
           paths:


### PR DESCRIPTION
The PR in #15 wasn't quite complete.

Without the full ingress-nginx ingress class stanza:

```
      ingressClassResource:
        name: internal
        default: true
        parameters:
          ingress-class: internal
```

both nginx ingress controllers will try to fulfill all valid `IngressClass`, so long as they use `ingressClassName`.

Not sure what is the deal with the default ingress class, or if it is a side-effect of the final deprecation of the `kubernetes.io/ingress.class` annotation ? This is what seemed to work.

Also, some helm charts [need to be updated](https://github.com/kingdonb/kubernetes-sso-guide/pull/1/files) to use `ingressClassName` instead of simply leaving it to the user as annotations. (That seemingly will not work anymore.)