### PR TITLE
try fixing the ingress-class as extraArgs

### DIFF
--- a/infrastructure/ingress-nginx/internal-helmrelease.yaml
+++ b/infrastructure/ingress-nginx/internal-helmrelease.yaml
@@ -19,8 +19,7 @@ spec:
     controller:
       extraArgs:
         enable-ssl-passthrough: ""
+        ingress-class: internal
       ingressClassResource:
         name: internal
         default: true
-        parameters:
-          ingress-class: internal

--- a/infrastructure/ingress-nginx/public-helmrelease.yaml
+++ b/infrastructure/ingress-nginx/public-helmrelease.yaml
@@ -21,8 +21,7 @@ spec:
     controller:
       extraArgs:
         enable-ssl-passthrough: ""
+        ingress-class: public
       ingressClassResource:
         name: public
         default: false
-        parameters:
-          ingress-class: public


### PR DESCRIPTION
```
missing required field "kind" in io.k8s.api.networking.v1.IngressClassParametersReference, ValidationError(IngressClass.spec.parameters): missing required field "name" in io.k8s.api.networking.v1.IngressClassParametersReference
```

(ingressClassResource.parameters is not an untyped field! whoops...)