### PR TITLE
Reliable jenkins helm install

### DIFF
--- a/apps/jenkins/helmrelease.yaml
+++ b/apps/jenkins/helmrelease.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  timeout: 1m
+  timeout: 3m
   releaseName: jenkins
   targetNamespace: jenkins
   storageNamespace: jenkins

--- a/clusters/moo-cluster/jenkins/flux-kustomization.yaml
+++ b/clusters/moo-cluster/jenkins/flux-kustomization.yaml
@@ -18,4 +18,4 @@ spec:
       kind: StatefulSet
       name: jenkins
       namespace: jenkins
-  timeout: 2m0s
+  timeout: 6m0s

--- a/clusters/moo-cluster/jenkins/flux-kustomization.yaml
+++ b/clusters/moo-cluster/jenkins/flux-kustomization.yaml
@@ -11,6 +11,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  dependsOn:
+    - name: persistence
   healthChecks:
     - apiVersion: apps/v1
       kind: StatefulSet

--- a/clusters/moo-cluster/local-path-provisioner/infrastructure.yaml
+++ b/clusters/moo-cluster/local-path-provisioner/infrastructure.yaml
@@ -13,3 +13,8 @@ spec:
   prune: false
   validation: client
   timeout: 5m0s
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: local-path-provisioner
+      namespace: local-path-storage


### PR DESCRIPTION
For Jenkins to install reliably and without delay, it will probably need persistence to be ready ahead of starting the installation process.