### PR TITLE
Fix validation error thrown from null healthChecks

### DIFF
--- a/infrastructure/linkerd/cluster.yaml
+++ b/infrastructure/linkerd/cluster.yaml
@@ -89,7 +89,6 @@ spec:
     kind: GitRepository
     name: linkerd-demos
   validation: client
-  healthChecks:
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
```
WARN - stdin contains an invalid Kustomization (flux-system.ambassador-crds) - spec.healthChecks: Invalid type. Expected: array, given: null
```

https://github.com/kingdon-ci/jenkins-infra/runs/3602742433

Checks failed on this commit: https://github.com/kingdon-ci/jenkins-infra/commit/b458cb1bbe221567112d8c17977a41155eb284dc