### PR TITLE
try to constrain keycloak

### DIFF
--- a/infrastructure/keycloak/kustomization.yaml
+++ b/infrastructure/keycloak/kustomization.yaml
@@ -35,3 +35,10 @@ patchesStrategicMerge:
          #  value: "admin"
           - name: PROXY_ADDRESS_FORWARDING
             value: "true"
+          resources:
+            requests:
+              memory: 512Mi
+              cpu: 250m
+            limits:
+              memory: 768Mi
+              cpu: 500m

--- a/infrastructure/keycloak/kustomization.yaml
+++ b/infrastructure/keycloak/kustomization.yaml
@@ -38,7 +38,7 @@ patchesStrategicMerge:
           resources:
             requests:
               memory: 512Mi
-              cpu: 250m
+              cpu: 25m
             limits:
               memory: 768Mi
               cpu: 500m


### PR DESCRIPTION
there is no requests/limits for file descriptors but maybe if we do not
give the JVM so much memory and CPU, it will not expand its footprint to
so many file descriptors:
```
$ sudo lsof | awk '{print $2}' | sort | uniq -c | sort -n
...
  85264 335736

$ ps wuax|grep 335736
kingdon   335736  2.8  3.2 1794176 530832 ?      Sl   18:54   0:45 java -D[Standalone] -server -Xms64m -Xmx512m 
-XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true --add-exports=java.base/sun.nio.ch=ALL-UNNAMED 
--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED -Dorg.jboss.boot.log.file=/opt/jboss/keycloak/standalone/log/server.log -Dlogging.configuration=file:/opt/jboss/keycloak/standalone/configuration/logging.properties 
-jar /opt/jboss/keycloak/jboss-modules.jar -mp /opt/jboss/keycloak/modules org.jboss.as.standalone -Djboss.home.dir=/opt/jboss/keycloak -Djboss.server.base.dir=/opt/jboss/keycloak/standalone 
-Djboss.bind.address=10.44.0.3 -Djboss.bind.address.private=10.44.0.3 -c=standalone-ha.xml -b 0.0.0.0
```